### PR TITLE
Fix top padding on keystroke

### DIFF
--- a/styles/background-tips.less
+++ b/styles/background-tips.less
@@ -22,7 +22,7 @@ background-tips {
 
       .keystroke {
         border: 2px solid;
-        padding: 0 @component-padding/2;
+        padding: @component-padding/2 @component-padding/2 0;
         border-radius: @component-border-radius * 3;
         font-family: Helvetica, Arial, sans-serif;
       }


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/241156/6107027/a1bd6500-b05e-11e4-8c03-caea842695e4.png)

After:
![after](https://cloud.githubusercontent.com/assets/241156/6107028/a1be6176-b05e-11e4-8d32-3ffa893c03d7.png)
