### PR TITLE
Add CSS to make .keystroke look like inline code blocks

### DIFF
--- a/styles/background-tips.less
+++ b/styles/background-tips.less
@@ -24,7 +24,11 @@ background-tips {
         border: 2px solid;
         padding: 0 @component-padding/2;
         border-radius: @component-border-radius * 3;
-        font-family: "Helvetica Neue", Arial, sans-serif;
+        font-family: "Courier New", "Helvetica Neue", Arial, sans-serif;
+        border-color:#484848;
+        color:#151718;
+        background-color:#484848;
+        text-shadow:none;
       }
     }
   }


### PR DESCRIPTION
I added a few lines of CSS to `background-tips.less` to make items with `.keystroke` look more like inline code blocks. Here's what they look like now--

![image](https://cloud.githubusercontent.com/assets/12245158/7788674/6a121d7a-01f9-11e5-89e5-78e21667d3fe.png)
