### PR TITLE
Clarify split pane and other multi-keystrokes

### DIFF
--- a/lib/background-tips-view.coffee
+++ b/lib/background-tips-view.coffee
@@ -97,8 +97,8 @@ class BackgroundTipsElement extends HTMLElement
         binding = @getKeyBindingForCurrentPlatform(bindings)
 
       if binding?.keystrokes
-        keystrokeLabel = _.humanizeKeystroke(binding.keystrokes).replace(/\s+/g, '&nbsp;')
-        "<span class=\"keystroke\">#{keystrokeLabel}</span>"
+        keystrokeLabel = _.humanizeKeystroke(binding.keystrokes).replace(/\s+/g, '</span>&thinsp;<span class="keystroke">')
+        "<span class='keystroke'>#{keystrokeLabel}</span>"
       else
         command
     str


### PR DESCRIPTION
Currently the keystroke to split a pane right is <kbd>⌘K →</kbd>, this is confusing, and I’m not the first one to note this either:

>[Split Pane Not Working](https://discuss.atom.io/t/split-pane-not-working/1755)
>Trying to split the panes in Atom, with cmd-k right, nothing seems to happen. No errors in the console either.

>Just wanted to raise the issue.

>Great work guys!

I now know that to split a pane right, it’s <kbd>⌘K</kbd> [release] <kbd>→</kbd>.

My suggestion is simple: where there are two or more separate groups of keystrokes, group them as such: <kbd>⌘K</kbd>&thinsp;<kbd>→</kbd>

Here you can see the the current styling at the top. The second example is something I briefly toyed with, comma separating the keys, but then it could easily be read as though the comma key were part of the keystroke.

The last example is what I’m suggesting, each keystroke group has been styled as such and there is a thin space between them:

![background tips shortcut suggestion](https://cloud.githubusercontent.com/assets/155358/10292938/ca06fdda-6ba9-11e5-8c6f-fe57c2cf692e.png)

*My coding skillz aren’t up to much, so this could probably be better written.*