### PR TITLE
Remove position: relative on container

### DIFF
--- a/styles/background-tips.less
+++ b/styles/background-tips.less
@@ -4,10 +4,6 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-atom-workspace .horizontal .vertical {
-  position: relative;
-}
-
 background-tips {
   display: block;
   pointer-events: none;


### PR DESCRIPTION
:warning: Merge after https://github.com/atom/atom/pull/11274

`position: relative` will be part of the core styles, and not needed here anymore. See https://github.com/atom/atom/pull/11274
