### PR TITLE
Only examine center when adding background tips

### DIFF
--- a/lib/background-tips-view.coffee
+++ b/lib/background-tips-view.coffee
@@ -49,7 +49,8 @@ class BackgroundTipsElement extends HTMLElement
       @stop()
 
   shouldBeAttached: ->
-    atom.workspace.getPanes().length is 1 and not atom.workspace.getActivePaneItem()?
+    # TODO: Remove this after atom/atom#13977 lands in favor of unguarded `getCenter()` call
+    (atom.workspace.getCenter?() ? atom.workspace).getPanes().length is 1 and not atom.workspace.getActivePaneItem()?
 
   start: ->
     return if not @shouldBeAttached() or @interval?

--- a/spec/background-tips-spec.coffee
+++ b/spec/background-tips-spec.coffee
@@ -11,6 +11,9 @@ describe "BackgroundTips", ->
   BackgroundTipsView::DisplayDuration = 5
   BackgroundTipsView::FadeDuration = 1
 
+  # TODO: Remove this after atom/atom#13977 lands in favor of unguarded `getCenter()` calls
+  getCenter = -> atom.workspace.getCenter?() ? atom.workspace
+
   activatePackage = (callback) ->
     waitsForPromise ->
       atom.packages.activatePackage('background-tips').then ({mainModule}) ->
@@ -25,7 +28,7 @@ describe "BackgroundTips", ->
 
   describe "when the package is activated when there is only one pane", ->
     beforeEach ->
-      expect(atom.workspace.getPanes().length).toBe 1
+      expect(getCenter().getPanes().length).toBe 1
 
     describe "when the pane is empty", ->
       it "attaches the view after a delay", ->
@@ -56,7 +59,7 @@ describe "BackgroundTips", ->
   describe "when the package is activated when there are multiple panes", ->
     beforeEach ->
       atom.workspace.getActivePane().splitRight()
-      expect(atom.workspace.getPanes().length).toBe 2
+      expect(getCenter().getPanes().length).toBe 2
 
     it "does not attach the view", ->
       activatePackage ->
@@ -78,7 +81,7 @@ describe "BackgroundTips", ->
 
   describe "when the view is attached", ->
     beforeEach ->
-      expect(atom.workspace.getPanes().length).toBe 1
+      expect(getCenter().getPanes().length).toBe 1
 
       activatePackage ->
         advanceClock BackgroundTipsView::StartDelay


### PR DESCRIPTION
This complements atom/atom#13977 and addresses test failures caused by its API changes.