### PR TITLE
Use pane:split-right-and-copy-active-item

### DIFF
--- a/lib/tips.js
+++ b/lib/tips.js
@@ -8,7 +8,7 @@ module.exports = [
   'You can focus the Git tab with {github:toggle-git-tab-focus}',
   'You can toggle the GitHub tab with {github:toggle-github-tab}',
   'You can focus the GitHub tab with {github:toggle-github-tab-focus}',
-  'You can split a pane with {pane:split-right}',
+  'You can split a pane with {pane:split-right-and-copy-active-item}',
   'You can jump to a method in the editor using {symbols-view:toggle-file-symbols}',
   'You can install packages and themes from the Settings View {settings-view:open}'
 ]


### PR DESCRIPTION
Some time ago, the pane split commands were changed and the default keybinding was reassigned to `pane:split-right-and-copy-active-item`.  Use that instead of `pane:split-right`, which now just creates an empty pane (not that useful...).