### PR TITLE
Use unprefixed user-select

### DIFF
--- a/styles/background-tips.less
+++ b/styles/background-tips.less
@@ -15,7 +15,7 @@ background-tips {
   overflow: hidden;
 
   .background-message {
-    -webkit-user-select: none;
+    user-select: none;
     cursor: default;
 
     .message {


### PR DESCRIPTION
There is now an unprefixed version of `user-select` available; we should use it.