### PR TITLE
🔥 unused `destroyed` variable

### DIFF
--- a/lib/background-tips-view.js
+++ b/lib/background-tips-view.js
@@ -31,7 +31,6 @@ class BackgroundTipsElement {
   destroy () {
     this.stop()
     this.disposables.dispose()
-    this.destroyed = true
   }
 
   attach () {


### PR DESCRIPTION
This isn't used anywhere.