### PR TITLE
Do not show background tips unless focused

### DIFF
--- a/lib/background-tips-view.js
+++ b/lib/background-tips-view.js
@@ -1,5 +1,5 @@
 const _ = require('underscore-plus')
-const {CompositeDisposable} = require('atom')
+const {CompositeDisposable, Disposable} = require('atom')
 const Tips = require('./tips')
 
 const TEMPLATE = `\
@@ -21,9 +21,17 @@ class BackgroundTipsElement {
 
     this.disposables = new CompositeDisposable()
 
-    this.disposables.add(this.workspaceCenter.onDidAddPane(() => this.updateVisibility()))
-    this.disposables.add(this.workspaceCenter.onDidDestroyPane(() => this.updateVisibility()))
-    this.disposables.add(this.workspaceCenter.onDidChangeActivePaneItem(() => this.updateVisibility()))
+    const visibilityCallback = () => this.updateVisibility()
+
+    this.disposables.add(this.workspaceCenter.onDidAddPane(visibilityCallback))
+    this.disposables.add(this.workspaceCenter.onDidDestroyPane(visibilityCallback))
+    this.disposables.add(this.workspaceCenter.onDidChangeActivePaneItem(visibilityCallback))
+
+    atom.getCurrentWindow().on('blur', visibilityCallback)
+    atom.getCurrentWindow().on('focus', visibilityCallback)
+
+    this.disposables.add(new Disposable(() => atom.getCurrentWindow().removeListener('blur', visibilityCallback)))
+    this.disposables.add(new Disposable(() => atom.getCurrentWindow().removeListener('focus', visibilityCallback)))
 
     this.startTimeout = setTimeout(() => this.start(), this.startDelay)
   }
@@ -61,7 +69,9 @@ class BackgroundTipsElement {
   }
 
   shouldBeAttached () {
-    return this.workspaceCenter.getPanes().length === 1 && this.workspaceCenter.getActivePaneItem() == null
+    return this.workspaceCenter.getPanes().length === 1 &&
+    this.workspaceCenter.getActivePaneItem() == null &&
+    atom.getCurrentWindow().isFocused()
   }
 
   start () {

--- a/spec/background-tips-spec.js
+++ b/spec/background-tips-spec.js
@@ -12,6 +12,7 @@ describe('BackgroundTips', () => {
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
     jasmine.useMockClock()
+    spyOn(atom.getCurrentWindow(), 'isFocused').andReturn(true)
   })
 
   describe('when the package is activated when there is only one pane', () => {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Only show background tips when Atom is focused to preserve battery life.

In the following GIFs, the slightly highlighted line in the Task Manager represents Atom.  Notice the GPU usage when Atom is and isn't focused.  (Note that I decreased the display duration to 1 second for a shorter GIF)

| Before | After |
| ------- | ------ |
|![background-tips-gpu-before](https://user-images.githubusercontent.com/2766036/36344360-406bb398-13e7-11e8-9a38-6233e02eeeea.gif)|![background-tips-gpu-after](https://user-images.githubusercontent.com/2766036/36344361-44d6726a-13e7-11e8-9a9f-6d2c64dd8df8.gif)|

### Alternate Designs

None.

### Benefits

Uses public Atom and Electron APIs to detect when Atom isn't focused and deactivates the background tips and timers in order to save battery life.  I have verified that the new listeners are disposed of correctly when the package is deactivated.

### Possible Drawbacks

When Atom is still visible but not focused, no background tips will appear.

### Applicable Issues

None.